### PR TITLE
Update requirements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yaml]
+indent_size = 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-acme==1.0.0
 certbot==1.0.0
 exonetapi==2.1.0
 tldextract==2.2.2
 requests==2.20.0
 zope.interface==4.7.1
+acme==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-requests==2.20.0
 zope.interface==4.7.1
 acme==1.7.0
 certbot==1.7.0
 exonetapi==3.0.3
 tldextract==3.1.0
+requests==2.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-zope.interface==4.7.1
 acme==1.7.0
 certbot==1.7.0
 exonetapi==3.0.3
 tldextract==3.1.0
 requests==2.25.1
+zope.interface==5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-certbot==1.0.0
 exonetapi==2.1.0
 tldextract==2.2.2
 requests==2.20.0
 zope.interface==4.7.1
 acme==1.7.0
+certbot==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-tldextract==2.2.2
 requests==2.20.0
 zope.interface==4.7.1
 acme==1.7.0
 certbot==1.7.0
 exonetapi==3.0.3
+tldextract==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-exonetapi==2.1.0
 tldextract==2.2.2
 requests==2.20.0
 zope.interface==4.7.1
 acme==1.7.0
 certbot==1.7.0
+exonetapi==3.0.3


### PR DESCRIPTION
Updating exonetapi to 3.0.3 which is needed to [fix an issue](https://github.com/exonet/exonet-api-python/releases/tag/3.0.3) with python 3.5. Also updated all other requirements to the versions which are still compatible with python 3.5. All packages have been tested on a Debian 9 server with python 3.5.3.

Changes:
- [acme](https://github.com/certbot/certbot/blob/master/certbot/CHANGELOG.md)
- [certbot](https://github.com/certbot/certbot/blob/master/certbot/CHANGELOG.md)
- [exonetapi](https://github.com/exonet/exonet-api-python/releases)
- [tldextract](https://github.com/john-kurkowski/tldextract/blob/master/CHANGELOG.md)
- [requests](https://github.com/psf/requests/blob/main/HISTORY.md)
- [zope.interface](https://github.com/zopefoundation/zope.interface/blob/master/CHANGES.rst)